### PR TITLE
return ID on create and support root CA

### DIFF
--- a/get.go
+++ b/get.go
@@ -8,11 +8,12 @@ import (
 )
 
 type ClusterResp struct {
-	APIEndpoint     string               `json:"api_endpoint"`
-	CreateDate      time.Time            `json:"create_date"`
-	ID              string               `json:"id"`
-	Name            string               `json:"name"`
-	ServiceAccounts []ServiceAccountResp `json:"service_accounts"`
+	APIEndpoint              string               `json:"api_endpoint"`
+	CertificateAuthorityData string               `json:"certificate_authority_data"`
+	CreateDate               time.Time            `json:"create_date"`
+	ID                       string               `json:"id"`
+	Name                     string               `json:"name"`
+	ServiceAccounts          []ServiceAccountResp `json:"service_accounts"`
 }
 
 type ServiceAccountResp struct {


### PR DESCRIPTION
This extends the API and aligns it with the specified mock API. See https://github.com/giantswarm/mock-api.

See also
- https://github.com/giantswarm/api/pull/222
- https://github.com/giantswarm/cluster-service/pull/4
- https://github.com/giantswarm/mock-api/pull/14

RFR @marians @oponder @JosephSalisbury 
