### PR TITLE
fixed default response

### DIFF
--- a/service/keypair/lister/response.go
+++ b/service/keypair/lister/response.go
@@ -16,11 +16,6 @@ type Response struct {
 }
 
 // DefaultResponse provides a default response by best effort.
-func DefaultResponse() *Response {
-	return &Response{
-		CreateDate:   time.Time{},
-		Description:  "",
-		SerialNumber: "",
-		TTL:          0,
-	}
+func DefaultResponse() []*Response {
+	return []*Response{}
 }


### PR DESCRIPTION
This PR fixes the default response of the keypair lister. It has to be a list, not a plain object.