### PR TITLE
Change string to int for storage and memory

### DIFF
--- a/service/cluster/creator/config/memory.go
+++ b/service/cluster/creator/config/memory.go
@@ -8,6 +8,6 @@ type Memory struct {
 // DefaultMemory provides a default ram configuration by best effort.
 func DefaultMemory() *Memory {
 	return &Memory{
-		SizeGB: 1,
+		SizeGB: 0,
 	}
 }

--- a/service/cluster/creator/config/storage.go
+++ b/service/cluster/creator/config/storage.go
@@ -8,6 +8,6 @@ type Storage struct {
 // DefaultStorage provides a default storage configuration by best effort.
 func DefaultStorage() *Storage {
 	return &Storage{
-		SizeGB: 20,
+		SizeGB: 0,
 	}
 }

--- a/service/cluster/searcher/config/memory.go
+++ b/service/cluster/searcher/config/memory.go
@@ -8,6 +8,6 @@ type Memory struct {
 // DefaultMemory provides a default ram configuration by best effort.
 func DefaultMemory() *Memory {
 	return &Memory{
-		SizeGB: 1,
+		SizeGB: 0,
 	}
 }

--- a/service/cluster/searcher/config/storage.go
+++ b/service/cluster/searcher/config/storage.go
@@ -8,6 +8,6 @@ type Storage struct {
 // DefaultStorage provides a default storage configuration by best effort.
 func DefaultStorage() *Storage {
 	return &Storage{
-		SizeGB: 20,
+		SizeGB: 0,
 	}
 }


### PR DESCRIPTION
This change should ensure that when fetching cluster details, memory and storage size in GB (`size_gb` in JSON) are delivered as integers.

Parent: https://github.com/giantswarm/api/pull/310