### PR TITLE
Check for the right status code

### DIFF
--- a/service/cluster/updater/service.go
+++ b/service/cluster/updater/service.go
@@ -104,7 +104,7 @@ func (s *Service) Update(ctx context.Context, request Request) (*Response, error
 		}
 
 		return nil, maskAnyf(invalidRequestError, responseError.Error)
-	} else if r.StatusCode() != http.StatusCreated {
+	} else if r.StatusCode() != http.StatusOK {
 		return nil, maskAny(fmt.Errorf(string(r.Body())))
 	}
 


### PR DESCRIPTION
In the update service I was checking for the wrong status code. Cluster Service sends statusOK when the update succeeds, not statusCreating.