### PR TITLE
Add common_name and certificate_organizations to the get keypairs response

### DIFF
--- a/service/keypair/lister/response.go
+++ b/service/keypair/lister/response.go
@@ -4,10 +4,14 @@ import "time"
 
 // Response is the return value of the service action.
 type Response struct {
+	// CommonName is the common name that the certifcate was issued with.
+	CommonName string `json:"common_name"`
 	// CreateDate represents the timestamp of the serial items creation.
 	CreateDate time.Time `json:"create_date"`
 	// Description represents the description associated with an issued key-pair.
 	Description string `json:"description"`
+	// Organizations represents the organizations that the certificate was issued with.
+	Organizations string `json:"certificate_organizations"`
 	// SerialNumber represents the fingerprint of an issued key-pair.
 	SerialNumber string `json:"serial_number"`
 	// TTL represents the time the number of hours the key-pair associated with


### PR DESCRIPTION
So that the API can show users what they typed in when they created the keypair.