### PR TITLE
adds scaling to updater request

### DIFF
--- a/service/cluster/updater/config/patch.go
+++ b/service/cluster/updater/config/patch.go
@@ -7,6 +7,7 @@ type Patch struct {
 	Name           string                 `json:"name"`
 	Owner          string                 `json:"owner"`
 	ReleaseVersion string                 `json:"release_version,omitempty"`
+	Scaling        Scaling                `json:"scaling,omitempty"`
 	VersionBundles []versionbundle.Bundle `json:"version_bundles,omitempty"`
 	Workers        []Worker               `json:"workers,omitempty"`
 }
@@ -17,6 +18,7 @@ func DefaultPatch() Patch {
 		Name:           "",
 		Owner:          "",
 		ReleaseVersion: "",
+		Scaling:        Scaling{},
 		VersionBundles: []versionbundle.Bundle{},
 		Workers:        []Worker{},
 	}

--- a/service/cluster/updater/config/scaling.go
+++ b/service/cluster/updater/config/scaling.go
@@ -1,0 +1,6 @@
+package config
+
+type Scaling struct {
+	Max int `json:"max"`
+	Min int `json:"min"`
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/pull/2206. We use this for the API wiring so that clusters can be scaled via the cluster/updater endpoint in the `api`. 