### PR TITLE
Change Zones type to string slice

### DIFF
--- a/service/info/azure/response/availability_zones.go
+++ b/service/info/azure/response/availability_zones.go
@@ -1,7 +1,7 @@
 package response
 
 type AvailabilityZones struct {
-	DefaultCount int   `json:"default"`
-	MaxCount     int   `json:"max"`
-	Zones        []int `json:"zones,omitempty"`
+	DefaultCount int      `json:"default"`
+	MaxCount     int      `json:"max"`
+	Zones        []string `json:"zones,omitempty"`
 }


### PR DESCRIPTION
The reason for doing this is that `cluster-service` has common availability zones types for Azure and AWS, so instead of converting the Azure AZs in the API, I propose doing it in `cluster-service`, to have a more consistent implementation